### PR TITLE
ci: ワークフローの修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ workflows:
       - front-deploy:
           requires:
             - front-build
-            - api-test
+            - aws-ecr/build-and-push-image
           filters:
             branches:
               only: main


### PR DESCRIPTION
front-deployをaws-ecr/build-and-push-imageの後にする

